### PR TITLE
FIX: font Consolas not loaded

### DIFF
--- a/pretty_putty_dark.reg
+++ b/pretty_putty_dark.reg
@@ -49,6 +49,8 @@ Windows Registry Editor Version 5.00
 "Font"="Consolas"
 "FontHeight"=dword:0000000c
 "FontQuality"=dword:00000003
+"FontCharSet"=dword:00000000
+"FontIsBold"=dword:00000000
 
 ; Linux style copy-and-pasting (middle click to paste)
 "MouseIsXterm"=dword:00000001

--- a/pretty_putty_light.reg
+++ b/pretty_putty_light.reg
@@ -49,6 +49,8 @@ Windows Registry Editor Version 5.00
 "Font"="Consolas"
 "FontHeight"=dword:0000000c
 "FontQuality"=dword:00000003
+"FontCharSet"=dword:00000000
+"FontIsBold"=dword:00000000
 
 ; Linux style copy-and-pasting (middle click to paste)
 "MouseIsXterm"=dword:00000001


### PR DESCRIPTION
Added registry keys "FontIsBold" and "FontCharSet". Their absence prevented the "Consolas" font to be used on sessions.
Tested on Windows 10 and PuTTY 0.81